### PR TITLE
Py-compile-3.7: change args per issue 811

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -30,7 +30,7 @@ def _pip_import_impl(repository_ctx):
             "--build-isolation",
             "--no-emit-find-links",
             "--no-header",
-            "--no-index",
+            "--no-emit-index-url",
             "--no-annotate",
             repository_ctx.path("requirements.txt"),
         ], quiet = repository_ctx.attr.quiet)


### PR DESCRIPTION
As discussed in https://github.com/jazzband/pip-tools/issues/811 with a quick change at https://github.com/jazzband/pip-tools/issues/811#issuecomment-1058233070, py-compile-3.7.0 no longer accepts `--no-index`, fairly suddenly as well.

The `--no-emit-index-url` is a replacement.

For upstream, probably need to make it check the version of the interpreter, or allow user-setting.